### PR TITLE
Add group condition support and document DB schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,10 @@ proxy-monitoring-system/
 python -m ppat_db.policy_db sample_data/policy_combined.json
 ```
 위 명령을 실행하면 정책 그룹과 룰뿐 아니라 객체 목록이 `policy_lists`
-테이블에 저장되며, 각 룰의 조건은 `policy_conditions` 테이블을 통해 관리됩니다.
+테이블에 저장되며, 그룹과 룰의 모든 조건은 `policy_conditions` 테이블에서
+확인할 수 있습니다. 조건에는 괄호 개수를 나타내는 `open_bracket`,
+`close_bracket` 컬럼이 포함됩니다.
+보다 자세한 스키마 설명은 `docs/db_schema.md` 파일을 참고하세요.
 
 ## 문제 해결
 

--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -1,0 +1,13 @@
+# 데이터베이스 스키마
+
+다음 표는 정책 관련 데이터를 저장하기 위해 사용되는 주요 테이블입니다.
+
+| 테이블 | 설명 |
+| ------ | ---- |
+| `policy_groups` | 정책 그룹 정보. 그룹 ID와 경로, 원본 JSON이 저장됩니다. |
+| `policy_rules` | 개별 룰 정보. 룰 ID와 소속 그룹 경로를 포함합니다. |
+| `policy_conditions` | 그룹과 룰의 조건을 저장합니다. `rule_id` 또는 `group_id` 를 통해 어느 객체의 조건인지 구분하며, 괄호 개수(`open_bracket`, `close_bracket`)와 비교 연산자 등이 기록됩니다. |
+| `policy_lists` | 정책에서 참조하는 객체 리스트 항목을 저장합니다. |
+| `condition_list_map` | 조건이 참조하는 리스트 ID를 매핑합니다. |
+
+각 테이블의 컬럼은 `ppat_db/policy_db.py`의 SQLAlchemy 모델 정의에서 확인할 수 있습니다.

--- a/tests/test_policy_db.py
+++ b/tests/test_policy_db.py
@@ -1,0 +1,102 @@
+import sys
+import types
+import pytest
+
+# Patch external dependencies used in policy_module
+sys.modules.setdefault("pandas", types.ModuleType("pandas")).DataFrame = lambda *a, **k: type("DF", (), {"to_excel": lambda self, *args, **kwargs: None})()
+sys.modules.setdefault("xmltodict", types.ModuleType("xmltodict")).parse = lambda s: {}
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+import ppat_db.policy_db as pdb
+
+
+def setup_function(_):
+    pdb.engine = create_engine("sqlite:///:memory:")
+    pdb.Session = sessionmaker(bind=pdb.engine)
+    pdb.Base.metadata.create_all(pdb.engine)
+
+
+def test_save_policy_with_group_conditions():
+    policy = {
+        "libraryContent": {
+            "ruleGroup": {
+                "@id": "g1",
+                "@name": "Group1",
+                "condition": {
+                    "expressions": {
+                        "conditionExpression": {
+                            "@prefix": "URL",
+                            "@operatorId": "equals",
+                            "@openingBracketCount": "1",
+                            "@closingBracketCount": "0",
+                            "propertyInstance": {
+                                "@propertyId": "URL.Host",
+                                "parameters": {
+                                    "entry": {
+                                        "string": "domain",
+                                        "parameter": {
+                                            "@valueType": "value",
+                                            "value": {"stringValue": {"@value": "example.com"}}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "rules": {
+                    "rule": {
+                        "@id": "r1",
+                        "@name": "Rule1",
+                        "condition": {
+                            "expressions": {
+                                "conditionExpression": {
+                                    "@prefix": "URL",
+                                    "@operatorId": "equals",
+                                    "@openingBracketCount": "0",
+                                    "@closingBracketCount": "1",
+                                    "propertyInstance": {
+                                        "@propertyId": "URL.Host",
+                                        "parameters": {
+                                            "entry": {
+                                                "string": "domain",
+                                                "parameter": {
+                                                    "@valueType": "value",
+                                                    "value": {"stringValue": {"@value": "example.net"}}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pdb.save_policy_to_db(policy)
+
+    with pdb.Session() as session:
+        groups = session.query(pdb.PolicyGroup).all()
+        rules = session.query(pdb.PolicyRule).all()
+        conds = session.query(pdb.PolicyCondition).order_by(pdb.PolicyCondition.index).all()
+
+        assert len(groups) == 1
+        assert len(rules) == 1
+        assert len(conds) == 2
+
+        g_cond = conds[0]
+        r_cond = conds[1]
+
+        assert g_cond.group_id == "g1"
+        assert g_cond.open_bracket == 1
+        assert g_cond.close_bracket == 0
+
+        assert r_cond.rule_id == "r1"
+        assert r_cond.open_bracket == 0
+        assert r_cond.close_bracket == 1


### PR DESCRIPTION
## Summary
- store policy group conditions in `policy_conditions`
- record bracket counts via `open_bracket` and `close_bracket`
- document DB schema
- test DB save logic (skipped without SQLAlchemy)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a70063d08320a205614bc2de1cc3