### PR TITLE
Handle extended policy structures

### DIFF
--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -6,8 +6,10 @@
 | ------ | ---- |
 | `policy_groups` | 정책 그룹 정보. 그룹 ID와 경로, 원본 JSON이 저장됩니다. |
 | `policy_rules` | 개별 룰 정보. 룰 ID와 소속 그룹 경로를 포함합니다. |
-| `policy_conditions` | 그룹과 룰의 조건을 저장합니다. `rule_id` 또는 `group_id` 를 통해 어느 객체의 조건인지 구분하며, 괄호 개수(`open_bracket`, `close_bracket`)와 비교 연산자 등이 기록됩니다. |
+| `policy_conditions` | 그룹과 룰의 조건을 저장합니다. `rule_id` 또는 `group_id` 를 통해 어느 객체의 조건인지 구분하며, 중첩 구조를 위해 `parent_id` 필드를 사용합니다. 괄호 개수(`open_bracket`, `close_bracket`)와 비교 연산자 등이 기록됩니다. |
 | `policy_lists` | 정책에서 참조하는 객체 리스트 항목을 저장합니다. |
 | `condition_list_map` | 조건이 참조하는 리스트 ID를 매핑합니다. |
+| `policy_configurations` | configuration 정보를 별도로 저장합니다. |
+| `configuration_properties` | 각 configuration의 property 값을 보관합니다. |
 
 각 테이블의 컬럼은 `ppat_db/policy_db.py`의 SQLAlchemy 모델 정의에서 확인할 수 있습니다.

--- a/policy_module/configurations_parser.py
+++ b/policy_module/configurations_parser.py
@@ -1,0 +1,60 @@
+import xmltodict
+
+class ConfigurationsParser:
+    def __init__(self, source, from_xml: bool = False) -> None:
+        if from_xml:
+            self.data = xmltodict.parse(source)
+        elif isinstance(source, dict):
+            self.data = source
+        else:
+            raise ValueError("Invalid data source provided. Must be dict or XML string.")
+        self.records = []
+
+    @staticmethod
+    def parse_properties(conf: dict) -> list[dict]:
+        props = conf.get("configurationProperties", {}).get("configurationProperty")
+        result = []
+        if props is None:
+            return result
+        if not isinstance(props, list):
+            props = [props]
+        for p in props:
+            if not isinstance(p, dict):
+                continue
+            result.append(
+                {
+                    "key": p.get("@key"),
+                    "value": p.get("@value"),
+                    "type": p.get("@type"),
+                    "encrypted": p.get("@encrypted"),
+                    "list_type": p.get("@listType"),
+                }
+            )
+        return result
+
+    @staticmethod
+    def ensure_list(value):
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        return [value]
+
+    def parse(self):
+        configs = self.data.get("libraryContent", {}).get("configurations", {}).get("configuration")
+        for conf in self.ensure_list(configs):
+            if not isinstance(conf, dict):
+                continue
+            record = {
+                "id": conf.get("@id"),
+                "name": conf.get("@name"),
+                "version": conf.get("@version"),
+                "mwg_version": conf.get("@mwg-version"),
+                "template_id": conf.get("@templateId"),
+                "target_id": conf.get("@targetId"),
+                "description": conf.get("description"),
+                "properties": self.parse_properties(conf),
+                "raw": conf,
+            }
+            self.records.append(record)
+        return self.records

--- a/policy_module/policy_manager.py
+++ b/policy_module/policy_manager.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Iterable, List, Optional
 
 from .lists_parser import ListsParser
 from .policy_parser import PolicyParser
+from .configurations_parser import ConfigurationsParser
 
 
 class ListDatabase:
@@ -49,6 +50,10 @@ class PolicyManager:
         records = parser.parse()
         self.list_db.load(records)
         return records
+
+    def parse_configurations(self) -> List[Dict[str, Any]]:
+        parser = ConfigurationsParser(self.policy_source, from_xml=self.from_xml)
+        return parser.parse()
 
     def parse_policy(self) -> tuple:
         rulegroups, rules = self.policy_parser.parse()

--- a/policy_module/policy_parser.py
+++ b/policy_module/policy_parser.py
@@ -36,8 +36,12 @@ class PolicyParser:
                     parsed_conditions = self.parse_condition(obj.get("condition", {}))
                     if not isinstance(parsed_conditions, list):
                         parsed_conditions = [parsed_conditions]
-                    
-                    for idx, cond in enumerate(parsed_conditions):
+                    if not parsed_conditions:
+                        parsed_conditions = [None]
+
+                    for cond in parsed_conditions:
+                        cond = cond or {}
+                        first = cond.get("index", 1) == 1
                         values = cond.get("property_values")
                         if isinstance(values, (list, tuple)):
                             condition_values = ", ".join(values)
@@ -47,34 +51,36 @@ class PolicyParser:
                             condition_values = None
                         
                         record = {
-                            "id": obj.get("@id") if idx == 0 else None,
-                            "name": obj.get("@name") if idx == 0 else None,
-                            "enabled": obj.get("@enabled") if idx == 0 else None,
-                            "description": obj.get("description") if idx == 0 else None,
+                            "id": obj.get("@id") if first else None,
+                            "name": obj.get("@name") if first else None,
+                            "enabled": obj.get("@enabled") if first else None,
+                            "description": obj.get("description") if first else None,
                             "condition_raw": cond,  # 전체 반환 데이터를 저장
                             "condition_prefix": cond.get("prefix"),
                             "condition_property": cond.get("property"),
                             "condition_operator": cond.get("operator"),
                             "condition_values": condition_values,
                             "condition_result": cond.get("expression_value"),
+                            "condition_index": cond.get("index"),
+                            "condition_parent_index": cond.get("parent_index"),
                             "path": " > ".join(stack + [current_name] if current_name else stack)
                         }
                         if is_group:
                             record.update({
-                                "defaultRights": obj.get("@defaultRights") if idx == 0 else None,
-                                "cycleRequest": obj.get("@cycleRequest") if idx == 0 else None,
-                                "cycleResponse": obj.get("@cycleResponse") if idx == 0 else None,
-                                "cycleEmbeddedObject": obj.get("@cycleEmbeddedObject") if idx == 0 else None,
-                                "cloudSynced": obj.get("@cloudSynced") if idx == 0 else None,
-                                "acElements": str(obj.get("acElements")) if idx == 0 else None,
+                                "defaultRights": obj.get("@defaultRights") if first else None,
+                                "cycleRequest": obj.get("@cycleRequest") if first else None,
+                                "cycleResponse": obj.get("@cycleResponse") if first else None,
+                                "cycleEmbeddedObject": obj.get("@cycleEmbeddedObject") if first else None,
+                                "cloudSynced": obj.get("@cloudSynced") if first else None,
+                                "acElements": str(obj.get("acElements")) if first else None,
                                 "type": "group"
                             })
                             self.rulegroup_records.append(record)
                         else:
                             record.update({
-                                "actionContainer_raw": str(obj.get("actionContainer")) if idx == 0 else None,
-                                "immediateActions_raw": str(obj.get("immediateActionContainers")) if idx == 0 else None,
-                                "group_path": " > ".join(stack) if idx == 0 else None,
+                                "actionContainer_raw": str(obj.get("actionContainer")) if first else None,
+                                "immediateActions_raw": str(obj.get("immediateActionContainers")) if first else None,
+                                "group_path": " > ".join(stack) if first else None,
                                 "type": "rule"
                             })
                             self.rule_records.append(record)

--- a/ppat_db/policy_db.py
+++ b/ppat_db/policy_db.py
@@ -37,6 +37,7 @@ class PolicyCondition(Base):
     id = Column(Integer, primary_key=True)
     rule_id = Column(String(100))
     group_id = Column(String(100))
+    parent_id = Column(Integer, ForeignKey("policy_conditions.id"), nullable=True)
     index = Column(Integer)
     prefix = Column(String(50))
     open_bracket = Column(Integer, default=0)
@@ -69,6 +70,32 @@ class PolicyList(Base):
     description = Column(Text)
 
 
+class PolicyConfiguration(Base):
+    __tablename__ = "policy_configurations"
+
+    id = Column(Integer, primary_key=True)
+    configuration_id = Column(String(100))
+    name = Column(String(200))
+    version = Column(String(50))
+    mwg_version = Column(String(50))
+    template_id = Column(String(100))
+    target_id = Column(String(100))
+    description = Column(Text)
+    raw = Column(Text)
+
+
+class ConfigurationProperty(Base):
+    __tablename__ = "configuration_properties"
+
+    id = Column(Integer, primary_key=True)
+    configuration_id = Column(Integer, ForeignKey("policy_configurations.id"))
+    key = Column(String(200))
+    value = Column(Text)
+    type = Column(String(100))
+    encrypted = Column(String(10))
+    list_type = Column(String(100))
+
+
 engine = create_engine("sqlite:///policy.db")
 Base.metadata.create_all(engine)
 Session = sessionmaker(bind=engine)
@@ -84,6 +111,7 @@ def save_policy_to_db(
     manager = PolicyManager(policy_source, list_source, from_xml=from_xml)
     list_records = manager.parse_lists()
     groups, rules = manager.parse_policy()
+    configs = manager.parse_configurations()
 
     with Session() as session:
         for l in list_records:
@@ -100,6 +128,7 @@ def save_policy_to_db(
 
         current_group_id: str | None = None
         group_condition_index = 0
+        group_parent_map: dict[int, int] = {}
         for g in groups:
             if g.get("id"):
                 current_group_id = g.get("id")
@@ -111,14 +140,17 @@ def save_policy_to_db(
                 )
                 session.merge(record)
                 group_condition_index = 0
+                group_parent_map = {}
             if current_group_id is None:
                 continue
-            group_condition_index += 1
             cond = g.get("condition_raw") or {}
+            idx = g.get("condition_index") or (group_condition_index + 1)
+            group_condition_index = idx
             cond_record = PolicyCondition(
                 rule_id=None,
                 group_id=current_group_id,
-                index=group_condition_index,
+                index=idx,
+                parent_id=group_parent_map.get(g.get("condition_parent_index")),
                 prefix=cond.get("prefix"),
                 open_bracket=int(cond.get("open_bracket", 0)),
                 close_bracket=int(cond.get("close_bracket", 0)),
@@ -132,6 +164,7 @@ def save_policy_to_db(
             )
             session.add(cond_record)
             session.flush()
+            group_parent_map[idx] = cond_record.id
             values = cond.get("property_values")
             list_ids: list[str] = []
             if isinstance(values, str) and values in manager.list_db.lists:
@@ -147,6 +180,7 @@ def save_policy_to_db(
 
         current_rule_id: str | None = None
         condition_index = 0
+        rule_parent_map: dict[int, int] = {}
         for r in rules:
             if r.get("id"):
                 current_rule_id = r.get("id")
@@ -158,14 +192,17 @@ def save_policy_to_db(
                 )
                 session.merge(record)
                 condition_index = 0
+                rule_parent_map = {}
             if current_rule_id is None:
                 continue
-            condition_index += 1
             cond = r.get("condition_raw") or {}
+            idx = r.get("condition_index") or (condition_index + 1)
+            condition_index = idx
             cond_record = PolicyCondition(
                 rule_id=current_rule_id,
                 group_id=None,
-                index=condition_index,
+                index=idx,
+                parent_id=rule_parent_map.get(r.get("condition_parent_index")),
                 prefix=cond.get("prefix"),
                 open_bracket=int(cond.get("open_bracket", 0)),
                 close_bracket=int(cond.get("close_bracket", 0)),
@@ -177,6 +214,7 @@ def save_policy_to_db(
             )
             session.add(cond_record)
             session.flush()
+            rule_parent_map[idx] = cond_record.id
             values = cond.get("property_values")
             list_ids: list[str] = []
             if isinstance(values, str) and values in manager.list_db.lists:
@@ -187,6 +225,31 @@ def save_policy_to_db(
                         list_ids.append(v)
             for lid in list_ids:
                 session.add(ConditionListMap(condition_id=cond_record.id, list_id=lid))
+
+        for conf in configs:
+            cfg = PolicyConfiguration(
+                configuration_id=conf.get("id"),
+                name=conf.get("name"),
+                version=conf.get("version"),
+                mwg_version=conf.get("mwg_version"),
+                template_id=conf.get("template_id"),
+                target_id=conf.get("target_id"),
+                description=conf.get("description"),
+                raw=json.dumps(conf, ensure_ascii=False),
+            )
+            session.add(cfg)
+            session.flush()
+            for prop in conf.get("properties", []):
+                session.add(
+                    ConfigurationProperty(
+                        configuration_id=cfg.id,
+                        key=prop.get("key"),
+                        value=prop.get("value"),
+                        type=prop.get("type"),
+                        encrypted=prop.get("encrypted"),
+                        list_type=prop.get("list_type"),
+                    )
+                )
 
         session.commit()
 

--- a/sample_data/policy_with_configurations.json
+++ b/sample_data/policy_with_configurations.json
@@ -1,0 +1,23 @@
+{
+    "libraryContent": {
+        "configurations": {
+            "configuration": {
+                "@id": "conf1",
+                "@name": "Sample Config",
+                "@version": "1.0",
+                "@mwg-version": "11",
+                "@templateId": "tmpl",
+                "@targetId": "target",
+                "description": "conf desc",
+                "configurationProperties": {
+                    "configurationProperty": {
+                        "@key": "prop1",
+                        "@value": "val1",
+                        "@type": "string",
+                        "@encrypted": "false"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/test_condition_parser.py
+++ b/tests/test_condition_parser.py
@@ -1,0 +1,64 @@
+import sys, types
+sys.modules.setdefault("pandas", types.ModuleType("pandas")).DataFrame = lambda *a, **k: None
+sys.modules.setdefault("xmltodict", types.ModuleType("xmltodict")).parse = lambda s: {}
+import os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from policy_module.condition_parser import ConditionParser
+
+
+def test_nested_parent_indexes():
+    cond = {
+        "expressions": {
+            "conditionExpression": [
+                {
+                    "@openingBracketCount": "1",
+                    "@operatorId": "equals",
+                    "propertyInstance": {"@propertyId": "A"}
+                },
+                {
+                    "@closingBracketCount": "1",
+                    "@operatorId": "equals",
+                    "propertyInstance": {"@propertyId": "B"}
+                }
+            ]
+        }
+    }
+    rows = ConditionParser(cond).to_rows()
+    assert rows[0]["index"] == 1
+    assert rows[0]["parent_index"] is None
+    assert rows[1]["index"] == 2
+    assert rows[1]["parent_index"] == 1
+
+
+def test_expression_parameter_value_capture():
+    cond = {
+        "expressions": {
+            "conditionExpression": {
+                "@operatorId": "equals",
+                "propertyInstance": {"@propertyId": "URL.Host"},
+                "parameter": {
+                    "@valueType": "value",
+                    "value": {"listValue": {"@id": "list1"}}
+                },
+            }
+        }
+    }
+    rows = ConditionParser(cond).to_rows()
+    assert rows[0]["property_values"] == "list1"
+
+
+def test_expression_parameter_string_capture():
+    cond = {
+        "expressions": {
+            "conditionExpression": {
+                "@operatorId": "equals",
+                "propertyInstance": {"@propertyId": "URL.Host"},
+                "parameter": {
+                    "@valueType": "value",
+                    "value": {"stringValue": {"@value": "example.com"}}
+                },
+            }
+        }
+    }
+    rows = ConditionParser(cond).to_rows()
+    assert rows[0]["property_values"] == "example.com"

--- a/tests/test_configurations_parser.py
+++ b/tests/test_configurations_parser.py
@@ -1,0 +1,35 @@
+import sys, types
+sys.modules.setdefault("pandas", types.ModuleType("pandas")).DataFrame = lambda *a, **k: type("DF", (), {"to_excel": lambda self, *args, **kwargs: None})()
+sys.modules.setdefault("xmltodict", types.ModuleType("xmltodict")).parse = lambda s: {}
+
+import json
+import os
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from policy_module.policy_manager import PolicyManager
+
+SAMPLE_PATH = os.path.join(os.path.dirname(__file__), "..", "sample_data", "policy_with_configurations.json")
+
+
+def load_data():
+    with open(SAMPLE_PATH, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_parse_configurations():
+    data = load_data()
+    pm = PolicyManager(data, from_xml=False)
+    configs = pm.parse_configurations()
+    assert len(configs) == 1
+    conf = configs[0]
+    assert conf["id"] == "conf1"
+    assert conf["name"] == "Sample Config"
+    assert conf["template_id"] == "tmpl"
+    assert len(conf["properties"]) == 1
+    prop = conf["properties"][0]
+    assert prop["key"] == "prop1"
+    assert prop["value"] == "val1"
+
+

--- a/tests/test_extended_data.py
+++ b/tests/test_extended_data.py
@@ -25,7 +25,7 @@ def test_parse_extended_policy():
     groups, rules = pm.parse_policy()
 
     assert len(lists) == 4
-    assert len(groups) == 0
+    assert len(groups) == 3
     assert len([r for r in rules if r.get("id")]) == 3
     r3_conditions = [r for r in rules if r.get("id") == "r3"]
     assert len(r3_conditions) == 1

--- a/tests/test_policy_db.py
+++ b/tests/test_policy_db.py
@@ -11,6 +11,8 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 import ppat_db.policy_db as pdb
+import json
+import os
 
 
 def setup_function(_):
@@ -94,9 +96,31 @@ def test_save_policy_with_group_conditions():
         r_cond = conds[1]
 
         assert g_cond.group_id == "g1"
+        assert g_cond.parent_id is None
         assert g_cond.open_bracket == 1
         assert g_cond.close_bracket == 0
 
         assert r_cond.rule_id == "r1"
+        assert r_cond.parent_id is None
         assert r_cond.open_bracket == 0
         assert r_cond.close_bracket == 1
+
+
+def test_save_policy_configurations():
+    path = os.path.join(os.path.dirname(__file__), "..", "sample_data", "policy_with_configurations.json")
+    with open(path, "r", encoding="utf-8") as f:
+        policy = json.load(f)
+
+    pdb.save_policy_to_db(policy)
+
+    with pdb.Session() as session:
+        configs = session.query(pdb.PolicyConfiguration).all()
+        props = session.query(pdb.ConfigurationProperty).all()
+        assert len(configs) == 1
+        assert len(props) == 1
+        conf = configs[0]
+        prop = props[0]
+        assert conf.configuration_id == "conf1"
+        assert conf.name == "Sample Config"
+        assert prop.key == "prop1"
+        assert prop.value == "val1"


### PR DESCRIPTION
## Summary
- improve list parsing for variable entry structures
- add configurations parser and expose via `PolicyManager`
- include minimal sample configuration data and tests
- store configuration records in database
- parse configuration properties and store them separately
- support nested condition parsing with parent tracking
- capture values from expression-level parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e4cb39588320aab7895032550561