### PR TITLE
Add ruleset download helper and fetch script

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,33 @@
+import json
+import os
+from flask import Flask, jsonify
+from policy_module.policy_manager import PolicyManager
+from ppat_db.policy_db import save_policy_to_db
+
+DATA_FILE = os.path.join(os.path.dirname(__file__), 'sample_data', 'policy_combined.json')
+
+app = Flask(__name__)
+
+@app.route('/parse-policy')
+def parse_policy():
+    """Parse sample policy and return groups and rules."""
+    with open(DATA_FILE, 'r', encoding='utf-8') as f:
+        policy = json.load(f)
+    manager = PolicyManager(policy, from_xml=False)
+    manager.parse_lists()
+    groups, rules = manager.parse_policy()
+    return jsonify({
+        'groups': groups,
+        'rules': rules,
+    })
+
+@app.route('/save-policy')
+def save_policy():
+    """Parse sample policy and store results into SQLite DB."""
+    with open(DATA_FILE, 'r', encoding='utf-8') as f:
+        policy = json.load(f)
+    save_policy_to_db(policy)
+    return jsonify({'status': 'saved'})
+
+if __name__ == '__main__':
+    app.run()

--- a/device_clients/skyhigh_client.py
+++ b/device_clients/skyhigh_client.py
@@ -88,6 +88,16 @@ class SkyhighSWGClient:
         else:
             raise Exception(f"Rule Set 목록 조회 실패: {response.status_code} {response.text}")
 
+    def download_ruleset_xml(self, ruleset_id):
+        """Download a rule set and return its XML content."""
+        url = self._build_url(f'rulesets/rulegroups/{ruleset_id}/export')
+        response = self.session.post(url, verify=self.verify_ssl)
+        if response.ok:
+            return response.content
+        raise Exception(
+            f"Rule Set '{ruleset_id}' 다운로드 실패: {response.status_code} {response.text}"
+        )
+
     def export_ruleset_to_xml_file(self, ruleset_id, title, output_dir='exports'):
         url = self._build_url(f'rulesets/rulegroups/{ruleset_id}/export')
         response = self.session.post(url, verify=self.verify_ssl)

--- a/fetch_policy.py
+++ b/fetch_policy.py
@@ -1,0 +1,32 @@
+import os
+from device_clients.skyhigh_client import SkyhighSWGClient
+from ppat_db.policy_db import save_policy_to_db
+
+
+def main():
+    base_url = os.environ.get("SKYHIGH_URL")
+    username = os.environ.get("SKYHIGH_USER")
+    password = os.environ.get("SKYHIGH_PASS")
+
+    if not all([base_url, username, password]):
+        print("SKYHIGH_URL, SKYHIGH_USER, SKYHIGH_PASS environment variables required")
+        return
+
+    client = SkyhighSWGClient(base_url, username, password, verify_ssl=False)
+    client.login()
+    rulesets = client.list_rulesets(top_level_only=True)
+    if not rulesets:
+        print("No rulesets found")
+        client.logout()
+        return
+
+    first = rulesets[0]
+    xml_data = client.download_ruleset_xml(first['id'])
+
+    save_policy_to_db(xml_data, from_xml=True)
+    client.logout()
+    print(f"Saved ruleset {first['title']} to database")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_policy_parser_xml.py
+++ b/tests/test_policy_parser_xml.py
@@ -1,0 +1,86 @@
+import sys, types
+sys.modules.setdefault("pandas", types.ModuleType("pandas")).DataFrame = lambda *a, **k: type("DF", (), {"to_excel": lambda self, *args, **kwargs: None})()
+
+_called = {}
+
+def fake_parse(xml_str):
+    _called["xml"] = xml_str
+    return combined_data
+
+xmltodict = types.ModuleType("xmltodict")
+xmltodict.parse = fake_parse
+sys.modules["xmltodict"] = xmltodict
+
+import importlib
+
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import policy_module.policy_parser as pp
+pp = importlib.reload(pp)
+from policy_module.policy_parser import PolicyParser
+
+combined_data = {
+    "libraryContent": {
+        "ruleGroup": {
+            "@id": "g1",
+            "@name": "Group1",
+            "rules": {
+                "rule": {
+                    "@id": "r1",
+                    "@name": "Rule1",
+                    "condition": {
+                        "expressions": {
+                            "conditionExpression": {
+                                "@prefix": "URL",
+                                "@operatorId": "equals",
+                                "propertyInstance": {
+                                    "@propertyId": "URL.Host",
+                                    "parameters": {
+                                        "entry": {
+                                            "string": "domain",
+                                            "parameter": {
+                                                "@valueType": "value",
+                                                "value": {"listValue": {"@id": "list1"}}
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "lists": {
+            "entry": [
+                {
+                    "list": {
+                        "@name": "Test List",
+                        "@id": "list1",
+                        "@typeId": "A",
+                        "@classifier": "string",
+                        "description": "desc",
+                        "content": {
+                            "listEntry": [
+                                {"@id": "entry1", "value": "example.com"},
+                                {"@id": "entry2", "value": "example.org"}
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+XML_INPUT = "<policy/>"
+
+def test_parse_policy_from_xml():
+    parser = PolicyParser(XML_INPUT, from_xml=True)
+    groups, rules = parser.parse()
+    assert _called.get("xml") == XML_INPUT
+    assert len(groups) == 1
+    assert groups[0]["id"] == "g1"
+    assert len(rules) == 1
+    assert rules[0]["name"] == "Rule1"


### PR DESCRIPTION
## Summary
- add `download_ruleset_xml` helper to `SkyhighSWGClient`
- provide standalone `fetch_policy.py` to login and store a rule set

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a0dcae2fc8320ac434d373b1df5c0