### PR TITLE
Fix integration tests to use real modules

### DIFF
--- a/monitoring_module/__init__.py
+++ b/monitoring_module/__init__.py
@@ -5,13 +5,11 @@
 
 from .config import Config as MonitoringConfig
 from .resource import ResourceMonitor
-from .session import SessionMonitor
-from .utils import format_bytes, parse_size
+# SessionMonitor 클래스는 실제로 SessionManager로 구현되어 있다.
+from .session import SessionManager as SessionMonitor
 
 __all__ = [
     'MonitoringConfig',
     'ResourceMonitor',
-    'SessionMonitor',
-    'format_bytes',
-    'parse_size'
+    'SessionMonitor'
 ]

--- a/monitoring_module/resource.py
+++ b/monitoring_module/resource.py
@@ -1,5 +1,7 @@
 from pysnmp.hlapi import *
-from clients.ssh import SSHClient
+# Use a relative import to ensure the SSH client is found when the package is
+# executed without installation.
+from .clients.ssh import SSHClient
 from .config import Config
 from .utils import get_current_timestamp, validate_resource_data, logger, split_line
 

--- a/monitoring_module/session.py
+++ b/monitoring_module/session.py
@@ -1,5 +1,7 @@
 import pandas as pd
-from clients.ssh import SSHClient
+# Use a relative import so the SSH client can be resolved when this module is
+# imported as part of the package.
+from .clients.ssh import SSHClient
 from .config import Config
 from .utils import split_line
 

--- a/policy_module/condition_parser.py
+++ b/policy_module/condition_parser.py
@@ -1,0 +1,3 @@
+from .parsers.condition_parser import ConditionParser
+
+__all__ = ["ConditionParser"]

--- a/policy_module/policy_manager.py
+++ b/policy_module/policy_manager.py
@@ -7,9 +7,11 @@ records parsed by :class:`PolicyParser`.
 
 from typing import Any, Dict, Iterable, List, Optional
 
-from parsers.lists_parser import ListsParser
-from parsers.policy_parser import PolicyParser
-from parsers.configurations_parser import ConfigurationsParser
+# Use relative imports so that the parsers package is correctly resolved when
+# this module is used without installing the policy_module package.
+from .parsers.lists_parser import ListsParser
+from .parsers.policy_parser import PolicyParser
+from .parsers.configurations_parser import ConfigurationsParser
 
 
 class ListDatabase:

--- a/test_connection.py
+++ b/test_connection.py
@@ -1,27 +1,28 @@
 """프록시 연결 테스트
 
-SSH와 SNMP 연결을 테스트하고 기본 정보를 조회합니다.
+실제 프록시 장비에 접속해 리소스와 세션 정보를 조회한다. 환경에 따라
+의존 모듈이 없거나 테스트 대상이 없을 수 있으므로 조건부로 실행한다.
 """
 
 import logging
-from monitoring_module.clients.ssh import SSHClient
+import os
+import pytest
+
+pytest.importorskip("paramiko")
+pytest.importorskip("pysnmp")
+pytest.importorskip("pandas")
+
 from monitoring_module.config import Config, ProxyConfig, MonitoringConfig
 from monitoring_module.resource import ResourceMonitor
-from monitoring_module.session import SessionMonitor
+from monitoring_module.session import SessionManager
+from monitoring_module.clients.ssh import SSHClient
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def test_single_proxy(host: str, username: str = 'root', password: str = '123456', port: int = 22):
-    """단일 프록시 테스트
-    
-    Args:
-        host (str): 프록시 서버 IP
-        username (str): SSH 사용자 이름
-        password (str): SSH 비밀번호
-        port (int): SSH 포트
-    """
+def test_single_proxy(host: str, username: str = 'root', password: str = '123456', port: int = 22) -> bool:
+    """단일 프록시 테스트"""
     try:
         # 프록시 설정 생성
         proxy_config = ProxyConfig(
@@ -47,14 +48,18 @@ def test_single_proxy(host: str, username: str = 'root', password: str = '123456
             
             # 리소스 모니터링 테스트
             logger.info("리소스 모니터링 테스트 중...")
-            resource_monitor = ResourceMonitor(ssh)
-            resources = resource_monitor.get_resource_usage()
+            resource_monitor = ResourceMonitor(host, username, password)
+            resources = resource_monitor.get_resource_data()
             logger.info(f"리소스 사용량: {resources}")
             
             # 세션 모니터링 테스트
             logger.info("세션 모니터링 테스트 중...")
-            session_monitor = SessionMonitor(ssh)
-            sessions = session_monitor.get_active_sessions()
+            session_monitor = SessionManager(
+                host,
+                username,
+                password,
+            )
+            sessions = session_monitor.get_session()
             logger.info(f"활성 세션 수: {len(sessions)}")
             
             logger.info("모든 테스트 완료")
@@ -63,6 +68,17 @@ def test_single_proxy(host: str, username: str = 'root', password: str = '123456
     except Exception as e:
         logger.error(f"테스트 실패: {str(e)}")
         return False
+
+
+def test_connection():
+    """환경 변수에 지정된 프록시에 실제 연결을 시도한다."""
+    host = os.getenv("TEST_PROXY")
+    if not host:
+        pytest.skip("TEST_PROXY not set")
+    username = os.getenv("TEST_USERNAME", "root")
+    password = os.getenv("TEST_PASSWORD", "123456")
+    port = int(os.getenv("TEST_PORT", "22"))
+    assert test_single_proxy(host, username, password, port)
 
 if __name__ == "__main__":
     # 테스트할 프록시 서버 정보

--- a/test_policy.py
+++ b/test_policy.py
@@ -4,7 +4,14 @@
 """
 
 import logging
+import os
 import json
+import pytest
+
+pytest.importorskip("requests")
+pytest.importorskip("pandas")
+pytest.importorskip("xmltodict")
+
 from policy_module.clients.skyhigh_client import SkyhighSWGClient
 from policy_module.config import Config, ProxyConfig
 from policy_module.policy_manager import PolicyManager
@@ -14,7 +21,7 @@ from ppat_db.policy_db import PolicyDB, save_policy_to_db
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def test_policy_fetch(host: str, username: str, password: str):
+def test_policy_fetch(host: str, username: str, password: str) -> bool:
     """정책 조회 테스트
     
     Args:
@@ -78,6 +85,16 @@ def test_policy_fetch(host: str, username: str, password: str):
     except Exception as e:
         logger.error(f"테스트 실패: {str(e)}")
         return False
+
+
+def test_policy():
+    """환경 변수에 지정된 프록시에서 정책을 조회한다."""
+    host = os.getenv("TEST_PROXY")
+    username = os.getenv("TEST_USERNAME")
+    password = os.getenv("TEST_PASSWORD")
+    if not (host and username and password):
+        pytest.skip("proxy credentials not set")
+    assert test_policy_fetch(host, username, password)
 
 if __name__ == "__main__":
     # 테스트할 프록시 서버 정보


### PR DESCRIPTION
## Summary
- restore real connection and policy test logic
- skip integration tests when dependencies or environment variables are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3e10047c8320ad54aa4c61998e6e