### PR TITLE
Fix parser imports and session utilities

### DIFF
--- a/monitoring_module/__init__.py
+++ b/monitoring_module/__init__.py
@@ -5,13 +5,11 @@
 
 from .config import Config as MonitoringConfig
 from .resource import ResourceMonitor
-from .session import SessionMonitor
-from .utils import format_bytes, parse_size
+# SessionMonitor 클래스는 실제로 SessionManager로 구현되어 있다.
+from .session import SessionManager as SessionMonitor
 
 __all__ = [
     'MonitoringConfig',
     'ResourceMonitor',
-    'SessionMonitor',
-    'format_bytes',
-    'parse_size'
+    'SessionMonitor'
 ]

--- a/monitoring_module/session.py
+++ b/monitoring_module/session.py
@@ -1,17 +1,17 @@
 import pandas as pd
-from clients.ssh import SSHClient
-from .config import Config
+# Use a relative import so the SSH client can be resolved when this module is
+# imported as part of the package.
+from .clients.ssh import SSHClient
+from .config import Config, ProxyConfig
 from .utils import split_line
 
 class SessionManager:
-    def __init__(self, host, username=None, password=None):
-        self.host = host
-        self.username = username
-        self.password = password
+    def __init__(self, host: str, username: str | None = None, password: str | None = None, port: int = 22):
+        self.proxy = ProxyConfig(host=host, username=username or 'root', password=password or '123456', port=port)
 
     def get_session(self) -> pd.DataFrame:
         """프록시 서버의 세션 정보를 가져옴"""
-        with SSHClient(self.host, self.username, self.password) as ssh:
+        with SSHClient(self.proxy) as ssh:
             stdin, stdout, stderr = ssh.execute_command(Config.SESSION_CMD)
             lines = stdout.readlines()
 

--- a/policy_module/__init__.py
+++ b/policy_module/__init__.py
@@ -8,11 +8,13 @@ from .policy_manager import PolicyManager
 from .parsers.policy_parser import PolicyParser
 from .parsers.lists_parser import ListsParser
 from .parsers.configurations_parser import ConfigurationsParser
+from .parsers.condition_parser import ConditionParser
 
 __all__ = [
     'PolicyConfig',
     'PolicyManager',
     'PolicyParser',
     'ListsParser',
-    'ConfigurationsParser'
+    'ConfigurationsParser',
+    'ConditionParser'
 ]

--- a/policy_module/parsers/policy_parser.py
+++ b/policy_module/parsers/policy_parser.py
@@ -106,3 +106,10 @@ class PolicyParser:
         df_rules = pd.DataFrame(self.rule_records)
         df_groups.to_excel(group_path, index=False, engine="openpyxl")
         df_rules.to_excel(rule_path, index=False, engine="openpyxl")
+
+    def get_parsed_data(self):
+        """Return parsed rule groups and rules as a dict."""
+        return {
+            "rule_groups": self.rulegroup_records,
+            "rules": self.rule_records,
+        }

--- a/policy_module/policy_manager.py
+++ b/policy_module/policy_manager.py
@@ -7,9 +7,11 @@ records parsed by :class:`PolicyParser`.
 
 from typing import Any, Dict, Iterable, List, Optional
 
-from parsers.lists_parser import ListsParser
-from parsers.policy_parser import PolicyParser
-from parsers.configurations_parser import ConfigurationsParser
+# Use relative imports so that the parsers package is correctly resolved when
+# this module is used without installing the policy_module package.
+from .parsers.lists_parser import ListsParser
+from .parsers.policy_parser import PolicyParser
+from .parsers.configurations_parser import ConfigurationsParser
 
 
 class ListDatabase:

--- a/test_connection.py
+++ b/test_connection.py
@@ -1,27 +1,21 @@
 """프록시 연결 테스트
 
-SSH와 SNMP 연결을 테스트하고 기본 정보를 조회합니다.
+실제 프록시 장비에 접속해 리소스와 세션 정보를 조회한다.
 """
 
 import logging
-from monitoring_module.clients.ssh import SSHClient
+
 from monitoring_module.config import Config, ProxyConfig, MonitoringConfig
 from monitoring_module.resource import ResourceMonitor
-from monitoring_module.session import SessionMonitor
+from monitoring_module.session import SessionManager
+from monitoring_module.clients.ssh import SSHClient
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def test_single_proxy(host: str, username: str = 'root', password: str = '123456', port: int = 22):
-    """단일 프록시 테스트
-    
-    Args:
-        host (str): 프록시 서버 IP
-        username (str): SSH 사용자 이름
-        password (str): SSH 비밀번호
-        port (int): SSH 포트
-    """
+def test_single_proxy(host: str, username: str = 'root', password: str = '123456', port: int = 22) -> bool:
+    """단일 프록시 테스트"""
     try:
         # 프록시 설정 생성
         proxy_config = ProxyConfig(
@@ -47,14 +41,18 @@ def test_single_proxy(host: str, username: str = 'root', password: str = '123456
             
             # 리소스 모니터링 테스트
             logger.info("리소스 모니터링 테스트 중...")
-            resource_monitor = ResourceMonitor(ssh)
-            resources = resource_monitor.get_resource_usage()
+            resource_monitor = ResourceMonitor(host, username, password)
+            resources = resource_monitor.get_resource_data()
             logger.info(f"리소스 사용량: {resources}")
             
             # 세션 모니터링 테스트
             logger.info("세션 모니터링 테스트 중...")
-            session_monitor = SessionMonitor(ssh)
-            sessions = session_monitor.get_active_sessions()
+            session_monitor = SessionManager(
+                host,
+                username,
+                password,
+            )
+            sessions = session_monitor.get_session()
             logger.info(f"활성 세션 수: {len(sessions)}")
             
             logger.info("모든 테스트 완료")
@@ -63,6 +61,7 @@ def test_single_proxy(host: str, username: str = 'root', password: str = '123456
     except Exception as e:
         logger.error(f"테스트 실패: {str(e)}")
         return False
+
 
 if __name__ == "__main__":
     # 테스트할 프록시 서버 정보

--- a/test_policy.py
+++ b/test_policy.py
@@ -5,16 +5,16 @@
 
 import logging
 import json
+
 from policy_module.clients.skyhigh_client import SkyhighSWGClient
 from policy_module.config import Config, ProxyConfig
-from policy_module.policy_manager import PolicyManager
 from ppat_db.policy_db import PolicyDB, save_policy_to_db
 
 # 로깅 설정
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-def test_policy_fetch(host: str, username: str, password: str):
+def test_policy_fetch(host: str, username: str, password: str) -> bool:
     """정책 조회 테스트
     
     Args:
@@ -78,6 +78,7 @@ def test_policy_fetch(host: str, username: str, password: str):
     except Exception as e:
         logger.error(f"테스트 실패: {str(e)}")
         return False
+
 
 if __name__ == "__main__":
     # 테스트할 프록시 서버 정보

--- a/tests/test_condition_parser.py
+++ b/tests/test_condition_parser.py
@@ -3,7 +3,7 @@ sys.modules.setdefault("pandas", types.ModuleType("pandas")).DataFrame = lambda 
 sys.modules.setdefault("xmltodict", types.ModuleType("xmltodict")).parse = lambda s: {}
 import os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from policy_module.condition_parser import ConditionParser
+from policy_module.parsers.condition_parser import ConditionParser
 
 
 def test_nested_parent_indexes():


### PR DESCRIPTION
## Summary
- expose `ConditionParser` in policy module and remove unused wrapper
- implement `get_parsed_data` in `PolicyParser`
- update resource and session monitors to build `SSHClient` using `ProxyConfig`
- adjust condition parser tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pysnmp and pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685b3e10047c8320ad54aa4c61998e6e