### PR TITLE
Unify policy items

### DIFF
--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -4,8 +4,7 @@
 
 | 테이블 | 설명 |
 | ------ | ---- |
-| `policy_groups` | 정책 그룹 정보. 그룹 ID, 이름, 경로, 설명, 활성화 상태, 순서 등을 저장합니다. 계층 구조를 위한 `parent_group_id`를 포함하며, 원본 데이터는 `raw` JSON 필드에 저장됩니다. |
-| `policy_rules` | 개별 룰 정보. 룰 ID, 이름, 소속 그룹 경로, 설명, 활성화 상태, 순서, 액션 정보를 포함합니다. 액션 관련 추가 옵션은 `action_options` JSON 필드에, 원본 데이터는 `raw` JSON 필드에 저장됩니다. |
+| `policy_items` | 그룹과 룰을 통합한 항목 정보. ID, 유형(`group`/`rule`), 경로, 설명, 액션 정보 등을 포함하며 원본 데이터는 `raw` JSON 필드에 저장됩니다. |
 | `policy_conditions` | 그룹과 룰의 조건을 저장합니다. `rule_id` 또는 `group_id`로 소속을 구분하며, 중첩 구조를 위해 `parent_id`를 사용합니다. 괄호, 연산자, 속성값 등이 저장되며, 복잡한 속성값은 `values` JSON 필드에, 원본 데이터는 `raw` JSON 필드에 저장됩니다. |
 | `policy_lists` | 정책에서 참조하는 객체 리스트 항목을 저장합니다. 리스트 ID, 항목 ID, 값, 이름, 타입, 분류자, 설명을 포함하며, 추가 메타데이터는 `metadata` JSON 필드에, 원본 데이터는 `raw` JSON 필드에 저장됩니다. |
 | `condition_list_map` | 조건과 리스트 간의 다대다 관계를 매핑합니다. `condition_id`와 `list_id`로 연결됩니다. |
@@ -16,10 +15,7 @@
 
 ```mermaid
 erDiagram
-    policy_groups ||--o{ policy_groups : "parent-child"
-    policy_groups ||--o{ policy_rules : "contains"
-    policy_groups ||--o{ policy_conditions : "has"
-    policy_rules ||--o{ policy_conditions : "has"
+    policy_items ||--o{ policy_conditions : "has"
     policy_conditions ||--o{ policy_conditions : "parent-child"
     policy_conditions ||--o{ condition_list_map : "references"
     policy_lists ||--o{ condition_list_map : "referenced by"

--- a/docs/policy_manager.md
+++ b/docs/policy_manager.md
@@ -33,7 +33,7 @@ manager = PolicyManager(source_data, from_xml=True)
 # 2. 데이터 파싱
 lists = manager.parse_lists()
 configs = manager.parse_configurations()
-rulegroups, rules = manager.parse_policy()
+records = manager.parse_policy()
 ```
 
 ## 데이터 구조
@@ -91,7 +91,7 @@ classDiagram
         +policy_parser: PolicyParser
         +parse_lists() List
         +parse_configurations() List
-        +parse_policy() tuple
+        +parse_policy() List
         -_resolve(records) void
         -_resolve_values(values) Any
     }

--- a/docs/policy_store.md
+++ b/docs/policy_store.md
@@ -67,8 +67,7 @@ store.store_from_source(content, from_xml=False)
 class PolicyData:
     lists: List[Dict[str, Any]]          # 리스트 데이터
     configurations: List[Dict[str, Any]]  # 설정 데이터
-    rules: List[Dict[str, Any]]          # 규칙 데이터
-    groups: List[Dict[str, Any]]         # 그룹 데이터
+    items: List[Dict[str, Any]]          # 그룹/규칙 통합 데이터
 ```
 
 ## 데이터베이스 테이블
@@ -77,8 +76,7 @@ class PolicyData:
 |--------|------|
 | `policy_lists` | 정책 리스트 데이터 |
 | `policy_configurations` | 정책 설정 데이터 |
-| `policy_groups` | 정책 그룹 데이터 |
-| `policy_rules` | 정책 규칙 데이터 |
+| `policy_items` | 그룹/규칙 통합 데이터 |
 
 ## 에러 처리
 

--- a/policy_module/policy_store.py
+++ b/policy_module/policy_store.py
@@ -11,8 +11,8 @@ from sqlalchemy.orm import Session
 from .clients.skyhigh_client import SkyhighSWGClient
 from .policy_manager import PolicyManager
 from ppat_db.policy_db import (
-    PolicyList, PolicyConfiguration, 
-    PolicyGroup, PolicyRule
+    PolicyList, PolicyConfiguration,
+    PolicyItem
 )
 
 
@@ -21,8 +21,7 @@ class PolicyData:
     """정책 데이터 컨테이너"""
     lists: List[Dict[str, Any]]
     configurations: List[Dict[str, Any]]
-    rules: List[Dict[str, Any]]
-    groups: List[Dict[str, Any]]
+    items: List[Dict[str, Any]]
 
 
 class PolicyStore:
@@ -70,8 +69,7 @@ class PolicyStore:
         data = PolicyData(
             lists=manager.parse_lists(),
             configurations=manager.parse_configurations(),
-            groups=manager.parse_policy()[0],
-            rules=manager.parse_policy()[1]
+            items=manager.parse_policy(),
         )
         
         # 2. 단일 트랜잭션으로 저장
@@ -98,13 +96,10 @@ class PolicyStore:
         for config in data.configurations:
             self.session.add(PolicyConfiguration(**config))
             
-        for group in data.groups:
-            self.session.add(PolicyGroup(**group))
-            
-        for rule in data.rules:
-            self.session.add(PolicyRule(**rule))
+        for item in data.items:
+            self.session.add(PolicyItem(**item))
 
     def _clear_existing_data(self) -> None:
         """기존 데이터 삭제"""
-        for table in [PolicyList, PolicyConfiguration, PolicyGroup, PolicyRule]:
-            self.session.query(table).delete() 
+        for table in [PolicyList, PolicyConfiguration, PolicyItem]:
+            self.session.query(table).delete()


### PR DESCRIPTION
## Summary
- integrate groups and rules into `policy_items`
- update `PolicyStore` to use the unified structure
- revise database schema docs and manager docs
- adjust policy saving logic for new item format

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cf0484b908320a2a47b4017141aae